### PR TITLE
#17 #18 Update ECS AMIs and change ECR region to user-provided

### DIFF
--- a/aws/cfn.json
+++ b/aws/cfn.json
@@ -116,11 +116,11 @@
 
   "Mappings" : {
     "AWSRegionToECSAMI" : {
-      "us-east-1"      : { "AMIID" : "ami-33b48a59" },
-      "us-west-2"      : { "AMIID" : "ami-26f78746" },
-      "eu-west-1"      : { "AMIID" : "ami-77ab1504" },
-      "ap-northeast-1" : { "AMIID" : "ami-b3afa2dd" },
-      "ap-southeast-2" : { "AMIID" : "ami-cf6342ac" }
+      "us-east-1"      : { "AMIID" : "ami-67a3a90d" },
+      "us-west-2"      : { "AMIID" : "ami-c7a451a7" },
+      "eu-west-1"      : { "AMIID" : "ami-9c9819ef" },
+      "ap-northeast-1" : { "AMIID" : "ami-7e4a5b10" },
+      "ap-southeast-2" : { "AMIID" : "ami-b8cbe8db" }
     },
     "AWSRegionToLinuxAMI": {
       "us-east-1"      : { "AMIID" : "ami-08111162" },

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 #Change these to match your environment
-REGION=us-east-1 # do not change this since ECR is available only in us-east-1
+REGION=
 DOCKER_REGISTRY=
 DOCKER_REPO=svc-sundial
 # An s3 bucket for deployment assets


### PR DESCRIPTION
#17 
Update ECS AMI to fresh ones (see http://docs.aws.amazon.com/AmazonECS/latest/developerguide/launch_container_instance.html).

#18 
ECR is now available across the regions so we don't need to explicitly set us-east-1 region.