### PR TITLE
Fix possible cfn.yml typos, AWS wont parse

### DIFF
--- a/aws/cfn.yml
+++ b/aws/cfn.yml
@@ -594,8 +594,7 @@ Resources:
       - IpProtocol: tcp
         FromPort: '9000'
         ToPort: '9000'
-        CidrIp:
-          SourceSecurityGroupId: !GetAtt ['ServiceInstanceELBSecurityGroup', 'GroupId']
+        SourceSecurityGroupId: !GetAtt ['ServiceInstanceELBSecurityGroup', 'GroupId']
       VpcId: !Ref VpcId
   ServiceInstanceELBSecurityGroup:
     Type: AWS::EC2::SecurityGroup

--- a/aws/cfn.yml
+++ b/aws/cfn.yml
@@ -594,7 +594,8 @@ Resources:
       - IpProtocol: tcp
         FromPort: '9000'
         ToPort: '9000'
-        CidrIp: SourceSecurityGroupId: !GetAtt ['ServiceInstanceELBSecurityGroup', 'GroupId']
+        CidrIp:
+          SourceSecurityGroupId: !GetAtt ['ServiceInstanceELBSecurityGroup', 'GroupId']
       VpcId: !Ref VpcId
   ServiceInstanceELBSecurityGroup:
     Type: AWS::EC2::SecurityGroup
@@ -660,7 +661,7 @@ Resources:
           Statement:
           - Effect: Allow
             Action: ['batch:*']
-            Resource: ["*"]P
+            Resource: ["*"]
           - Effect: Allow
             Action: ['iam:passRole']
             Resource: ["*"]


### PR DESCRIPTION
Hello there, I was unable to initialize the stack on Cloudformation, AWS complained that cfn.yml wasn't valid yaml. I triple checked this on:

 - https://yaml-online-parser.appspot.com/
 - http://www.yamllint.com/

Both of them give syntax errors. These changes fix those errors and at least allow AWS and the former services to parse the file.
Let me know if I did anything stupid please, I'm not familiar enough with yaml. And thanks for making public such a cool project!

UPDATE: It builds correctly on Cloudformation.